### PR TITLE
chef-client is a special case we don't want to mangle

### DIFF
--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -102,7 +102,8 @@ class Chef
             ui.error("Expected a github user and a repo to download from: jnewland/chef_ipmi")
             exit 1
           end
-          @cookbook_name = @github_repo.gsub(/[_-]?chef(?!-client)[-_]?/, '').gsub(/[_-]?cookbook[-_]?/, '')
+          @cookbook_name = @github_repo.gsub(/[_-]?chef(?!-client|-server)[-_]?/, '').
+                                        gsub(/[_-]?cookbook[-_]?/, '')
         end
       end
 

--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -102,7 +102,7 @@ class Chef
             ui.error("Expected a github user and a repo to download from: jnewland/chef_ipmi")
             exit 1
           end
-          @cookbook_name = @github_repo.gsub(/[_-]?chef[-_]?/, '').gsub(/[_-]?cookbook[-_]?/, '')
+          @cookbook_name = @github_repo.gsub(/[_-]?chef(?!-client)[-_]?/, '').gsub(/[_-]?cookbook[-_]?/, '')
         end
       end
 
@@ -149,3 +149,4 @@ class Chef
     end
   end
 end
+


### PR DESCRIPTION
I tried `knife cookbook github install cookbooks/chef-client` and I ended up with it in `cookbooks/client`... whoops. This sidesteps that little edge case :-)
