### PR TITLE
Try to load the sha from tags if the branch can't be found

### DIFF
--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -141,11 +141,17 @@ class Chef
       end
 
       def sha
-        @sha ||= noauth_rest.get_rest("http://github.com/api/v2/json/repos/show/#{@github_user}/#{@github_repo}/branches")['branches'][github_branch]
+        @sha ||= get_sha('branches') || get_sha('tags')
       end
 
       def github_branch
         @github_branch ||= 'master'
+      end
+
+      private
+
+      def get_sha(type)
+        noauth_rest.get_rest("http://github.com/api/v2/json/repos/show/#{@github_user}/#{@github_repo}/#{type}")[type][github_branch]
       end
 
     end


### PR DESCRIPTION
Hi there,

I modified the cookbook_github-install script to try to retrieve the sha from tags if it can't find it in the branches. For my personal workflow, this is important; I like to stick to tagged releases while periodically comparing with master (using `knife cookbook github compare`) to see if I'm missing anything.

Without this patch, I can install using tags, but the commit is screwed up:

```
% knife cookbook github install fnichol/chef-rvm/v0.8.0
Installing rvm from git://github.com/fnichol/chef-rvm.git to /Users/chris/work/testing/rvm/.chef/../cookbooks
Checking out the master branch.
Creating pristine copy branch chef-vendor-rvm
Removing pre-existing version.
1 files updated, committing changes
Creating tag cookbook-site-imported-rvm-
Checking out the master branch.
Updating 4c574f5..958dc8b
Fast-forward
 cookbooks/rvm/.gitignore                           |    2 +
 cookbooks/rvm/CHANGELOG.md                         |   84 ++
...
 create mode 100644 cookbooks/rvm/templates/default/rvmrc.erb
 create mode 100644 cookbooks/rvm/templates/default/vagrant-chef-solo-wrapper.erb
Cookbook rvm version  successfully installed

% git log -1
commit 958dc8b9232e3b58d80c4be39b31f4aeea91e146
Author: Chris Turner <--->
Date:   Mon Aug 22 20:21:49 2011 -0700

    Import fnichol/chef-rvm version

% knife cookbook github compare rvm fnichol/chef-rvm -VV
DEBUG: Using configuration from /Users/chris/.chef/knife.rb
DEBUG: sh(git log chef-vendor-rvm -n 1)
commit 958dc8b9232e3b58d80c4be39b31f4aeea91e146
Author: Chris Turner <--->
Date:   Mon Aug 22 20:21:49 2011 -0700

    Import fnichol/chef-rvm version
/Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/gems/knife-github-cookbooks-0.1.5/lib/chef/knife/cookbook_github_compare.rb:63:in `run': undefined method `[]' for nil:NilClass (NoMethodError)
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/gems/chef-0.10.4/lib/chef/knife.rb:391:in `run_with_pretty_exceptions'
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/gems/chef-0.10.4/lib/chef/knife.rb:166:in `run'
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/gems/chef-0.10.4/lib/chef/application/knife.rb:128:in `run'
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/gems/chef-0.10.4/bin/knife:25
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/bin/knife:19:in `load'
    from /Users/chris/.rvm/gems/ruby-1.8.7-p352@chef/bin/knife:19

%
```
