### PR TITLE
Use absolute path to cookbooks directory

### DIFF
--- a/lib/chef/knife/cookbook_github_compare.rb
+++ b/lib/chef/knife/cookbook_github_compare.rb
@@ -55,7 +55,7 @@ class Chef
 
         @cookbook_name = parse_name_args!
 
-        @install_path = config[:cookbook_path].first
+        @install_path = Fle.expand_path(config[:cookbook_path].first)
 
         @repo = CookbookSCMRepoExtensions.new(@install_path, ui, config)
 

--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -69,7 +69,7 @@ class Chef
 
         parse_name_args!
 
-        @install_path = config[:cookbook_path].first
+        @install_path = File.expand_path(config[:cookbook_path].first)
         ui.info "Installing #@cookbook_name from #{github_uri} to #{@install_path}"
 
         @repo = CookbookSCMRepoExtensions.new(@install_path, ui, config)


### PR DESCRIPTION
Proposed fix for #8: Use File.expand_path on cookbook path so it's guaranteed to be an absolute path.  This allows users to specify a relative path in their chef config or on the command line:

```
knife cookbook github install --cookbook-path cookbooks cookbooks/yum
```
