### PR TITLE
Ensure cookbooks path exists before merging

### DIFF
--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -84,6 +84,7 @@ class Chef
 
         if @repo.finalize_updates_from_github(@cookbook_name, "#{@github_user}/#{@github_repo}", sha)
           @repo.reset_to_default_state
+          ensure_cookbooks_path_exists
           @repo.merge_updates_from(@cookbook_name, sha)
         else
           @repo.reset_to_default_state
@@ -130,6 +131,10 @@ class Chef
       def clear_existing_files(cookbook_path)
         ui.info("Removing pre-existing version.")
         shell_out!("rm -r #{cookbook_path}", :cwd => @install_path) if File.directory?(cookbook_path)
+      end
+
+      def ensure_cookbooks_path_exists
+        shell_out!("mkdir -p #{@install_path}", :cwd => tmpdir) unless File.exists?(@install_path)
       end
 
       def github_uri


### PR DESCRIPTION
Under the following circumstances, the cookbooks path will not exist after the
call to reset_to_default_state. In this instance, the directory should be
created before attempting to merge the new cookbook.
- cookbooks path is an empty subdirectory within an existing git repo (e.g, my_project/cookbooks)
- user attempts to install a cookbook `cd my_project; knife cookbook github install --cookbook-path cookbooks cookbooks/yum`
- knife clones the cookbook from github and commits it to a vendor branch
- upon switching back to the master branch, the (previously empty) cookbooks directory will no longer exist

In this instance, it should be safe to create the previously extant directory so the merge can be completed.
